### PR TITLE
chore(security): standardize SDLC security baseline (Homebrew tap)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot for a Homebrew tap: no runtime package manifest (Gemfile) exists,
+# so only the github-actions ecosystem applies — it keeps workflow action
+# versions current (supply-chain hardening). Grouped to minimize PR noise.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+# OpenSSF Scorecard: measures supply-chain security posture (branch protection,
+# pinned dependencies, token permissions, etc.) and reports to the Security tab.
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "20 7 * * 2"
+  push:
+    branches: ["development"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge.
+      id-token: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Applies the security baseline scoped to a **Homebrew tap** (formula-only repo, no runtime package manifest).

## Added
- **OpenSSF Scorecard** — supply-chain posture, results in the Security tab.
- **Dependabot** — `github-actions` ecosystem (the only applicable ecosystem) + grouped weekly updates.

## Enabled at repo settings (no file)
- Secret scanning + push protection
- Dependabot security updates
- Private vulnerability reporting

## Intentionally skipped
- **Dependency Review** / **Bandit** — no package manifest / not a Python repo.
- **CodeQL** — would not auto-configure (a single Ruby formula DSL has no analyzable application code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)